### PR TITLE
feat(frontend): pantalla responsive de Reportes en sección Estadísticas

### DIFF
--- a/front-vuejs/src/assets/estadisticas.css
+++ b/front-vuejs/src/assets/estadisticas.css
@@ -1,7 +1,135 @@
-#estadisticas {
-    background-color: #f1f8e9; /* Verde claro */
-    padding: 20px;
-    border-radius: 8px;
-    height: 100%;
-    box-sizing: border-box;
+.estadisticas-panel {
+  background: #f4f9ff;
+  border-radius: 14px;
+  padding: 16px;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #17324d;
+}
+
+.panel-header p {
+  margin: 4px 0 0;
+  color: #3f546a;
+  font-size: 0.95rem;
+}
+
+.report-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.tab-button {
+  min-height: 46px;
+  border: 1px solid #bfd6f2;
+  border-radius: 10px;
+  background: #e9f2fe;
+  color: #1e4a73;
+  font-weight: 600;
+  padding: 10px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.tab-button.active {
+  background: #1d6fd6;
+  color: #fff;
+  border-color: #1d6fd6;
+}
+
+.report-card,
+.result-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 14px;
+  border: 1px solid #dce8f7;
+}
+
+.report-card h3,
+.result-card h3 {
+  margin-top: 0;
+}
+
+.report-form {
+  display: grid;
+  gap: 10px;
+}
+
+.report-form-inline {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: end;
+}
+
+.report-form label {
+  font-weight: 600;
+  color: #2a4258;
+}
+
+.report-form input {
+  min-height: 44px;
+  border-radius: 8px;
+  border: 1px solid #c6d8ee;
+  padding: 8px 10px;
+  font-size: 1rem;
+}
+
+.report-form button {
+  min-height: 46px;
+  border: none;
+  border-radius: 10px;
+  background: #2b8a3e;
+  color: white;
+  font-weight: 700;
+  padding: 12px 14px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.report-form button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.message {
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.message.error {
+  background: #ffe5e5;
+  color: #8c1d1d;
+}
+
+.message.success {
+  background: #e5f8ea;
+  color: #1f6d33;
+}
+
+.result-card pre {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  background: #f8fbff;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+@media (max-width: 1024px) {
+  .report-tabs {
+    grid-template-columns: 1fr;
   }
+
+  .report-form-inline {
+    grid-template-columns: 1fr;
+  }
+}

--- a/front-vuejs/src/views/dashboard/Estadisticas.vue
+++ b/front-vuejs/src/views/dashboard/Estadisticas.vue
@@ -1,86 +1,173 @@
 <template>
-    <div class="cuadrante" id="estadisticas">
-      <h2>Estadísticas</h2>
-      <h2 class="text-center mb-4 text-primary">📊 Estadísticas de Gastos</h2>
-  
-      <div class="text-center mb-3">
-        <select v-model="anioSeleccionado" class="form-select w-auto d-inline-block me-2">
-          <option disabled value="">Seleccione un año</option>
-          <option v-for="anio in anios" :key="anio" :value="anio">{{ anio }}</option>
-        </select>
-  
-        <button
-          class="btn btn-success"
-          @click="fetchData"
-        >
-          Consultar
+  <section class="estadisticas-panel">
+    <header class="panel-header">
+      <h2>Estadísticas y Reportes</h2>
+      <p>Consultá reportes de negocio con una interfaz optimizada para desktop, tablet y pantallas táctiles.</p>
+    </header>
+
+    <div class="report-tabs" role="tablist" aria-label="Tipos de reportes">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        type="button"
+        class="tab-button"
+        :class="{ active: activeTab === tab.id }"
+        @click="activeTab = tab.id"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <article v-if="activeTab === 'gastosAltos'" class="report-card">
+      <h3>Gastos altos</h3>
+      <p>Endpoint: <code>GET /api/reportes/gastos-altos?monto_minimo=...</code></p>
+      <div class="report-form">
+        <label for="monto_minimo">Monto mínimo</label>
+        <input id="monto_minimo" v-model.number="gastosAltosForm.monto_minimo" type="number" min="0" step="0.01" />
+        <button type="button" @click="consultarGastosAltos" :disabled="loading">
+          {{ loading ? 'Consultando...' : 'Consultar gastos altos' }}
         </button>
       </div>
-  
-      <!-- Mostrar tabla solo si hay datos -->
-      <transition name="fade">
-        <div v-if="resultado !== null" class="card shadow p-4 mt-4">
-          <h4 class="text-center mb-3 text-secondary">
-            Total acumulado hasta Diciembre inclusive de {{ anioSeleccionado }} 💰
-          </h4>
-  
-          <div class="table-responsive">
-            <table class="table table-striped table-bordered align-middle text-center">
-              <thead class="table-dark">
-                <tr>
-                  <th>Año</th>
-                  <th>Total Gastos Acumulados</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{{ anioSeleccionado }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+    </article>
+
+    <article v-if="activeTab === 'ultimoGasto'" class="report-card">
+      <h3>Último gasto por titular</h3>
+      <p>Endpoint: <code>GET /api/reportes/ultimo-gasto/{cod_titular}</code></p>
+      <div class="report-form">
+        <label for="cod_titular">Código de titular</label>
+        <input id="cod_titular" v-model.number="ultimoGastoForm.cod_titular" type="number" min="1" step="1" />
+        <button type="button" @click="consultarUltimoGasto" :disabled="loading">
+          {{ loading ? 'Consultando...' : 'Consultar último gasto' }}
+        </button>
+      </div>
+    </article>
+
+    <article v-if="activeTab === 'ingresosMensuales'" class="report-card">
+      <h3>Ingresos mensuales</h3>
+      <p>Endpoint: <code>GET /api/reportes/ingresos-mensuales?anio=...&mes=...</code></p>
+      <div class="report-form report-form-inline">
+        <div>
+          <label for="anio">Año</label>
+          <input id="anio" v-model.number="ingresosMensualesForm.anio" type="number" min="2000" step="1" />
         </div>
-      </transition>
-    </div>
-  </template>
-  
-  <script>
-  export default {
-    name: "Estadistica",
-    data() {
-      return {
-        resultado: null,
-        anioSeleccionado: "",
-        anios: [2022, 2023, 2024, 2025],
-      };
-    },
-    methods: {
-      async fetchData() {
-        if (!this.anioSeleccionado) {
-          alert("Por favor seleccioná un año");
-          return;
-        }
-  
-        //Llamada a GET
-        try {
-          const response = await fetch(`http://localhost:9000/api/consolidado_gastos${this.anioSeleccionado}`);
-          if (!response.ok) throw new Error("Error en la respuesta del servidor");
-          this.resultado = await response.json();
-        } catch (error) {
-          console.error("Error al obtener datos:", error);
-          alert("No se pudieron obtener los datos");
-        }
-      },
-      volver() {
-      this.$router.push("/inicio"); // Regresa a la página principal
-    }
-    },
-  };
-  </script>
-  
-<style scoped>
-  .estadisticas {
-    padding: 10px;
+        <div>
+          <label for="mes">Mes</label>
+          <input id="mes" v-model.number="ingresosMensualesForm.mes" type="number" min="1" max="12" step="1" />
+        </div>
+        <button type="button" @click="consultarIngresosMensuales" :disabled="loading">
+          {{ loading ? 'Consultando...' : 'Consultar ingresos' }}
+        </button>
+      </div>
+    </article>
+
+    <p v-if="error" class="message error">{{ error }}</p>
+    <p v-if="success" class="message success">{{ success }}</p>
+
+    <section v-if="resultado" class="result-card">
+      <h3>Resultado</h3>
+      <pre>{{ JSON.stringify(resultado, null, 2) }}</pre>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import '@/assets/estadisticas.css'
+import { ref, reactive } from 'vue'
+import api from '@/helpers/api'
+
+const today = new Date()
+const tabs = [
+  { id: 'gastosAltos', label: 'Gastos altos' },
+  { id: 'ultimoGasto', label: 'Último gasto' },
+  { id: 'ingresosMensuales', label: 'Ingresos mensuales' }
+]
+
+const activeTab = ref('gastosAltos')
+const loading = ref(false)
+const error = ref('')
+const success = ref('')
+const resultado = ref(null)
+
+const gastosAltosForm = reactive({
+  monto_minimo: 10000
+})
+
+const ultimoGastoForm = reactive({
+  cod_titular: 1
+})
+
+const ingresosMensualesForm = reactive({
+  anio: today.getFullYear(),
+  mes: today.getMonth() + 1
+})
+
+const limpiarMensajes = () => {
+  error.value = ''
+  success.value = ''
+  resultado.value = null
+}
+
+const consultarGastosAltos = async () => {
+  limpiarMensajes()
+  if (gastosAltosForm.monto_minimo < 0) {
+    error.value = 'El monto mínimo debe ser mayor o igual a 0.'
+    return
   }
-</style>
-  
+
+  loading.value = true
+  try {
+    const response = await api.get('/reportes/gastos-altos', {
+      params: { monto_minimo: gastosAltosForm.monto_minimo }
+    })
+    resultado.value = response.data
+    success.value = 'Reporte de gastos altos obtenido correctamente.'
+  } catch (err) {
+    error.value = err.response?.data?.detail || 'No se pudo consultar el reporte de gastos altos.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const consultarUltimoGasto = async () => {
+  limpiarMensajes()
+  if (!ultimoGastoForm.cod_titular || ultimoGastoForm.cod_titular < 1) {
+    error.value = 'El código de titular debe ser un número mayor a 0.'
+    return
+  }
+
+  loading.value = true
+  try {
+    const response = await api.get(`/reportes/ultimo-gasto/${ultimoGastoForm.cod_titular}`)
+    resultado.value = response.data
+    success.value = 'Reporte de último gasto obtenido correctamente.'
+  } catch (err) {
+    error.value = err.response?.data?.detail || 'No se pudo consultar el último gasto del titular.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const consultarIngresosMensuales = async () => {
+  limpiarMensajes()
+  if (ingresosMensualesForm.mes < 1 || ingresosMensualesForm.mes > 12) {
+    error.value = 'El mes debe estar entre 1 y 12.'
+    return
+  }
+
+  loading.value = true
+  try {
+    const response = await api.get('/reportes/ingresos-mensuales', {
+      params: {
+        anio: ingresosMensualesForm.anio,
+        mes: ingresosMensualesForm.mes
+      }
+    })
+    resultado.value = response.data
+    success.value = 'Reporte de ingresos mensuales obtenido correctamente.'
+  } catch (err) {
+    error.value = err.response?.data?.detail || 'No se pudo consultar el reporte de ingresos mensuales.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>


### PR DESCRIPTION
### Motivation
- Reemplazar la vista antigua de estadísticas por una pantalla enfocada en los nuevos reportes de negocio y con mejor experiencia en desktop, tablet y pantallas táctiles.
- Exponer y consumir los 3 endpoints GET de `reportes` desde el frontend para facilitar consultas directas desde la UI.

### Description
- Reemplacé `front-vuejs/src/views/dashboard/Estadisticas.vue` por una nueva vista con navegación por tabs que implementa formularios y llamadas a los endpoints `GET /api/reportes/gastos-altos`, `GET /api/reportes/ultimo-gasto/{cod_titular}` y `GET /api/reportes/ingresos-mensuales` usando la instancia `api` existente.
- Añadí validaciones de entrada, indicadores de carga (`loading`), manejo de errores y mensajes de éxito, y renderizado del resultado en JSON para facilitar debugging y verificación rápida.
- Actualicé `front-vuejs/src/assets/estadisticas.css` con estilos responsivos y touch-friendly (botones y inputs con tamaños adecuados, layout adaptable y media queries para móviles/tablets).
- Los cambios están contenidos en la sección Estadísticas y no tocan rutas globales ni el backend; la vista reutiliza el helper `api` para autenticación y manejo de headers.

### Testing
- Ejecuté `cd front-vuejs && npm run build`, que falló en este entorno por `vite: not found` (dependencia no disponible), por lo que no se pudo generar el build final.
- Intenté `cd front-vuejs && npm install` para instalar dependencias, pero el entorno no dejó `vite` utilizable para completar el build, por lo que la verificación de producción quedó incompleta.
- Las modificaciones fueron añadidas y confirmadas en el repositorio local para revisión funcional en un entorno con dependencias de Node completas y `vite` instalado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52651ec80832f957328f9d7f03a2a)